### PR TITLE
Corrige para permitir mensagens entre conexões sem sumir com a mensagem do ticket que envia.

### DIFF
--- a/backend/src/database/migrations/20230304020754-add_fromMe_to_PK.ts
+++ b/backend/src/database/migrations/20230304020754-add_fromMe_to_PK.ts
@@ -1,0 +1,25 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+    */
+   return queryInterface.sequelize.query("ALTER TABLE Messages DROP PRIMARY KEY, ADD CONSTRAINT Messages_PK PRIMARY KEY (id, fromMe)");
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.dropTable('users');
+    */
+      return queryInterface.sequelize.query('ALTER TABLE Messages DROP CONSTRAINT Messages_PK, ADD PRIMARY KEY (id)');
+  }
+};

--- a/backend/src/models/Message.ts
+++ b/backend/src/models/Message.ts
@@ -27,6 +27,7 @@ class Message extends Model<Message> {
   @Column
   read: boolean;
 
+  @PrimaryKey
   @Default(false)
   @Column
   fromMe: boolean;


### PR DESCRIPTION
Atualmente ao enviar uma mensagem entre conexões do whaticket, ao atualizar a página a mensagem enviada some. O que ocorre é que a mensagem enviada e a recebida possuem o mesmo Id, de forma que, quando a outra conexão recebe a mensagem, a mensagem "enviada" tem seus dados alterados para os da mensagem "recebida".
Alterei para que a Primary Key de Messages seja (id, fromMe). Outro ponto a se considerar é se nao deve também ser utilizado o campo remote que está presente no "Id" da mensagem no whatsapp-web.js (imagem abaixo).
![image](https://user-images.githubusercontent.com/14986135/222872453-3353e3f3-e70b-453a-b1e8-1fc259a103d7.png)

Eu executei o comando up da migration direto no banco. É bom alguém testar o db:migrate e o db:migrate:undo pra ver se dá tudo certo.

Só testei que resolveu a questão de enviar as mensagens entre conexões. Como estou usando essa alteração, se surgir algum problema devido a isso eu aviso.
