### PR TITLE
Ignore whatsapp-web.js type definition - Fix #600

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
     "sequelize-typescript": "^1.1.0",
     "socket.io": "^3.0.5",
     "uuid": "^8.3.2",
-    "whatsapp-web.js": "^1.22.1",
+    "whatsapp-web.js": "^1.23.0",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -149,6 +149,8 @@ const verifyMessage = async (
     quotedMsgId: quotedMsg?.id
   };
 
+  // temporaryly disable ts checks because of type definition bug for Location object
+  // @ts-ignore
   await ticket.update({ lastMessage: msg.type === "location" ? msg.location.description ? "Localization - " + msg.location.description.split('\\n')[0] : "Localization" : msg.body });
 
   await CreateMessageService({ messageData });
@@ -159,6 +161,8 @@ const prepareLocation = (msg: WbotMessage): WbotMessage => {
 
   msg.body = "data:image/png;base64," + msg.body + "|" + gmapsUrl;
 
+  // temporaryly disable ts checks because of type definition bug for Location object
+  // @ts-ignore
   msg.body += "|" + (msg.location.description ? msg.location.description : (msg.location.latitude + ", " + msg.location.longitude))
 
   return msg;


### PR DESCRIPTION
Looks like whatsapp-web.js on version 1.23.0 changed the type definition of Location, mostly because a change on how to send the location. They removed the values for name, address, url and description from the Location object and created an Option object that includes only name, address and url.

**BUT**, received location stills come with the old format **AND** the code fails to build because of the type differences.

This pull request make whaticket compatible with whatsapp-web.js 1.23.0 bypassing typescript checks for two lines that uses the location.description value of messages.

I will open an issue on whatsapp-web.js so we can remove this bypass on the future.