### PR TITLE
Allow edit message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ssl/
 .env
 .wwebjs_auth
+.wwebjs_cache

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -16,3 +16,4 @@ yarn-error.log
 /coverage/
 
 .wwebjs_auth/
+.wwebjs_cache/

--- a/backend/src/controllers/MessageController.ts
+++ b/backend/src/controllers/MessageController.ts
@@ -9,6 +9,7 @@ import ShowTicketService from "../services/TicketServices/ShowTicketService";
 import DeleteWhatsAppMessage from "../services/WbotServices/DeleteWhatsAppMessage";
 import SendWhatsAppMedia from "../services/WbotServices/SendWhatsAppMedia";
 import SendWhatsAppMessage from "../services/WbotServices/SendWhatsAppMessage";
+import EditWhatsAppMessage from "../services/WbotServices/EditWhatsAppMessage";
 
 type IndexQuery = {
   pageNumber: string;
@@ -56,6 +57,21 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
 
   return res.send();
 };
+
+export const edit = async (req: Request, res: Response): Promise<Response> => {
+  const { messageId } = req.params;
+  const { body }: MessageData = req.body;
+
+  const message = await EditWhatsAppMessage(messageId, body);
+
+  const io = getIO();
+  io.to(message.ticketId.toString()).emit("appMessage", {
+    action: "update",
+    message
+  });
+
+  return res.send();
+}
 
 export const remove = async (
   req: Request,

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -10,6 +10,7 @@ import Queue from "../models/Queue";
 import WhatsappQueue from "../models/WhatsappQueue";
 import UserQueue from "../models/UserQueue";
 import QuickAnswer from "../models/QuickAnswer";
+import OldMessage from "../models/OldMessage";
 
 // eslint-disable-next-line
 const dbConfig = require("../config/database");
@@ -28,7 +29,8 @@ const models = [
   Queue,
   WhatsappQueue,
   UserQueue,
-  QuickAnswer
+  QuickAnswer,
+  OldMessage
 ];
 
 sequelize.addModels(models);

--- a/backend/src/database/migrations/20231114153108-add-isEdited-column-to-messages.ts
+++ b/backend/src/database/migrations/20231114153108-add-isEdited-column-to-messages.ts
@@ -1,0 +1,15 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.addColumn("Messages", "isEdited", {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    });
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.removeColumn("Messages", "isEdited");
+  }
+};

--- a/backend/src/database/migrations/20231117174628-create-oldMessages.ts
+++ b/backend/src/database/migrations/20231117174628-create-oldMessages.ts
@@ -1,0 +1,37 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.createTable("OldMessages", {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false
+      },
+      messageId: {
+        type: DataTypes.STRING,
+        references: { model: "Messages", key: "id"},
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+        allowNull: false
+      },
+      body: {
+        type: DataTypes.TEXT,
+        allowNull: false
+      },
+      createdAt: {
+        type: DataTypes.DATE(6),
+        allowNull: false
+      },
+      updatedAt: {
+        type: DataTypes.DATE(6),
+        allowNull: false
+      }
+    });
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.dropTable("OldMessages");
+  }
+};

--- a/backend/src/models/Message.ts
+++ b/backend/src/models/Message.ts
@@ -51,6 +51,10 @@ class Message extends Model<Message> {
   @Column
   isDeleted: boolean;
 
+  @Default(false)
+  @Column
+  isEdited: boolean;
+
   @CreatedAt
   @Column(DataType.DATE(6))
   createdAt: Date;

--- a/backend/src/models/Message.ts
+++ b/backend/src/models/Message.ts
@@ -8,10 +8,12 @@ import {
   PrimaryKey,
   Default,
   BelongsTo,
-  ForeignKey
+  ForeignKey,
+  HasMany
 } from "sequelize-typescript";
 import Contact from "./Contact";
 import Ticket from "./Ticket";
+import OldMessage from "./OldMessage";
 
 @Table
 class Message extends Model<Message> {
@@ -83,6 +85,9 @@ class Message extends Model<Message> {
 
   @BelongsTo(() => Contact, "contactId")
   contact: Contact;
+
+  @HasMany(() => OldMessage)
+  oldMessages: OldMessage[];
 }
 
 export default Message;

--- a/backend/src/models/OldMessage.ts
+++ b/backend/src/models/OldMessage.ts
@@ -1,0 +1,42 @@
+import {
+    Table,
+    Column,
+    CreatedAt,
+    UpdatedAt,
+    Model,
+    PrimaryKey,
+    ForeignKey,
+    BelongsTo,
+    DataType,
+    AutoIncrement   
+  } from "sequelize-typescript";
+
+import Message from "./Message";
+
+@Table
+class OldMessage extends Model<OldMessage> {
+  @PrimaryKey
+  @AutoIncrement
+  @Column
+  id: number;
+
+  @Column(DataType.TEXT)
+  body: string;
+
+  @CreatedAt
+  @Column(DataType.DATE(6))
+  createdAt: Date;
+
+  @UpdatedAt
+  @Column(DataType.DATE(6))
+  updatedAt: Date;
+
+  @ForeignKey(() => Message)
+  @Column
+  messageId: string;
+
+  @BelongsTo(() => Message)
+  message: Message;
+}
+
+export default OldMessage;

--- a/backend/src/routes/messageRoutes.ts
+++ b/backend/src/routes/messageRoutes.ts
@@ -18,6 +18,8 @@ messageRoutes.post(
   MessageController.store
 );
 
+messageRoutes.post("/messages/edit/:messageId", isAuth, MessageController.edit);
+
 messageRoutes.delete("/messages/:messageId", isAuth, MessageController.remove);
 
 export default messageRoutes;

--- a/backend/src/services/MessageServices/CreateMessageService.ts
+++ b/backend/src/services/MessageServices/CreateMessageService.ts
@@ -1,5 +1,6 @@
 import { getIO } from "../../libs/socket";
 import Message from "../../models/Message";
+import OldMessage from "../../models/OldMessage";
 import Ticket from "../../models/Ticket";
 import Whatsapp from "../../models/Whatsapp";
 
@@ -41,6 +42,10 @@ const CreateMessageService = async ({
         model: Message,
         as: "quotedMsg",
         include: ["contact"]
+      },
+      {
+        model: OldMessage,
+        as: "oldMessages"
       }
     ]
   });

--- a/backend/src/services/MessageServices/ListMessagesService.ts
+++ b/backend/src/services/MessageServices/ListMessagesService.ts
@@ -1,6 +1,7 @@
 import AppError from "../../errors/AppError";
 import Message from "../../models/Message";
 import Ticket from "../../models/Ticket";
+import OldMessage from "../../models/OldMessage";
 import ShowTicketService from "../TicketServices/ShowTicketService";
 
 interface Request {
@@ -38,6 +39,10 @@ const ListMessagesService = async ({
         model: Message,
         as: "quotedMsg",
         include: ["contact"]
+      },
+      {
+        model: OldMessage,
+        as: "oldMessages"
       }
     ],
     offset,

--- a/backend/src/services/WbotServices/EditWhatsAppMessage.ts
+++ b/backend/src/services/WbotServices/EditWhatsAppMessage.ts
@@ -1,0 +1,38 @@
+import AppError from "../../errors/AppError";
+import GetWbotMessage from "../../helpers/GetWbotMessage";
+import Message from "../../models/Message";
+import Ticket from "../../models/Ticket";
+
+const EditWhatsAppMessage = async (messageId: string, newBody: string): Promise<Message> => {
+  const message = await Message.findByPk(messageId, {
+    include: [
+      {
+        model: Ticket,
+        as: "ticket",
+        include: ["contact"]
+      }
+    ]
+  });
+
+  if (!message) {
+    throw new AppError("No message found with this ID.");
+  }
+
+  const { ticket } = message;
+
+  const messageToEdit = await GetWbotMessage(ticket, messageId);
+
+  try {
+    await messageToEdit.edit(newBody).then((res) => {
+        if (res === null) throw new Error("Can't edit");
+    });
+  } catch (err) {
+    throw new AppError("ERR_EDITING_WAPP_MSG");
+  }
+
+  await message.update({ isEdited: true });
+
+  return message;
+};
+
+export default EditWhatsAppMessage;

--- a/backend/src/services/WbotServices/EditWhatsAppMessage.ts
+++ b/backend/src/services/WbotServices/EditWhatsAppMessage.ts
@@ -23,9 +23,9 @@ const EditWhatsAppMessage = async (messageId: string, newBody: string): Promise<
   const messageToEdit = await GetWbotMessage(ticket, messageId);
 
   try {
-    await messageToEdit.edit(newBody).then((res) => {
-        if (res === null) throw new Error("Can't edit");
-    });
+    const res = await messageToEdit.edit(newBody);
+    if (res === null)
+      throw new Error("Can't edit");
   } catch (err) {
     throw new AppError("ERR_EDITING_WAPP_MSG");
   }

--- a/backend/src/services/WbotServices/EditWhatsAppMessage.ts
+++ b/backend/src/services/WbotServices/EditWhatsAppMessage.ts
@@ -30,8 +30,6 @@ const EditWhatsAppMessage = async (messageId: string, newBody: string): Promise<
     throw new AppError("ERR_EDITING_WAPP_MSG");
   }
 
-  await message.update({ isEdited: true });
-
   return message;
 };
 

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -476,8 +476,6 @@ const handleMsgEdit = async (
 
     await editedMsg.reload();
 
-    logger.info(JSON.stringify(editedMsg));
-
     io.to(editedMsg.ticketId.toString()).emit("appMessage", {
       action: "update",
       message: editedMsg

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -241,7 +241,8 @@ const isValidMsg = (msg: WbotMessage): boolean => {
 
 const handleMessage = async (
   msg: WbotMessage,
-  wbot: Session
+  wbot: Session,
+  newBody?: String
 ): Promise<void> => {
   if (!isValidMsg(msg)) {
     return;
@@ -250,6 +251,10 @@ const handleMessage = async (
   try {
     let msgContact: WbotContact;
     let groupContact: Contact | undefined;
+
+    if (newBody !== undefined) {
+      msg.body = newBody.toString();
+    }
 
     if (msg.fromMe) {
       // messages sent automatically by wbot have a special character in front of it
@@ -445,6 +450,10 @@ const handleMsgAck = async (msg: WbotMessage, ack: MessageAck) => {
 const wbotMessageListener = (wbot: Session): void => {
   wbot.on("message_create", async msg => {
     handleMessage(msg, wbot);
+  });
+
+  wbot.on("message_edit", async (msg, newBody) => {
+    handleMessage(msg, wbot, newBody);
   });
 
   wbot.on("media_uploaded", async msg => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "i18next-browser-languagedetector": "^6.0.1",
     "markdown-to-jsx": "^7.1.0",
     "mic-recorder-to-mp3": "^2.2.2",
+    "prop-types": "^15.8.1",
     "qrcode.react": "^1.0.0",
     "react": "^16.13.1",
     "react-color": "^2.19.3",
@@ -50,6 +51,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {}
+  }
 }

--- a/frontend/src/components/MessageHistoryModal/index.js
+++ b/frontend/src/components/MessageHistoryModal/index.js
@@ -1,0 +1,62 @@
+import React from "react";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import { TableContainer, Table, TableBody, TableRow, TableCell, makeStyles} from "@material-ui/core";
+
+import { parseISO, format } from "date-fns";
+
+import { i18n } from "../../translate/i18n";
+
+const useStyles = makeStyles((theme) => ({
+    timestamp: {
+        minWidth: 250
+    }
+}));
+
+const MessageHistoryModal = ({open, onClose, oldMessages}) => {
+    const classes = useStyles();
+
+    return (
+        <Dialog
+            open={open}
+            onClose={() => onClose(false)}
+            aria-labelledby="dialog-title"
+        >
+            <DialogTitle id="dialog-title">{i18n.t("messageHistoryModal.title")}</DialogTitle>
+            <DialogContent>
+                <TableContainer>
+                    <Table aria-label="message-history-table">
+                        <TableBody>
+                            {oldMessages && oldMessages.map((oldMessage) => (
+                                <TableRow
+                                    key={oldMessage.id}
+                                >
+                                    <TableCell component="th" scope="row">
+                                        {oldMessage.body}
+                                    </TableCell>
+                                    <TableCell align="right" className={classes.timestamp}>
+                                        {format(parseISO(oldMessage.createdAt), "dd/MM HH:mm")}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    autoFocus
+                    onClick={() => onClose(false)}
+                >
+                    {i18n.t("messageHistoryModal.close")}
+                </Button>
+            </DialogActions>
+
+        </Dialog>
+    );
+};
+
+export default MessageHistoryModal;

--- a/frontend/src/components/MessageHistoryModal/index.js
+++ b/frontend/src/components/MessageHistoryModal/index.js
@@ -1,62 +1,70 @@
 import React from "react";
+import PropTypes from "prop-types";
+
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import { TableContainer, Table, TableBody, TableRow, TableCell, makeStyles} from "@material-ui/core";
+import { TableContainer, Table, TableBody, TableRow, TableCell, makeStyles } from "@material-ui/core";
 
 import { parseISO, format } from "date-fns";
 
 import { i18n } from "../../translate/i18n";
 
 const useStyles = makeStyles((theme) => ({
-    timestamp: {
-        minWidth: 250
-    }
+  timestamp: {
+    minWidth: 250
+  }
 }));
 
-const MessageHistoryModal = ({open, onClose, oldMessages}) => {
-    const classes = useStyles();
+const MessageHistoryModal = ({ open, onClose, oldMessages }) => {
+  const classes = useStyles();
 
-    return (
-        <Dialog
-            open={open}
-            onClose={() => onClose(false)}
-            aria-labelledby="dialog-title"
-        >
-            <DialogTitle id="dialog-title">{i18n.t("messageHistoryModal.title")}</DialogTitle>
-            <DialogContent>
-                <TableContainer>
-                    <Table aria-label="message-history-table">
-                        <TableBody>
-                            {oldMessages && oldMessages.map((oldMessage) => (
-                                <TableRow
-                                    key={oldMessage.id}
-                                >
-                                    <TableCell component="th" scope="row">
-                                        {oldMessage.body}
-                                    </TableCell>
-                                    <TableCell align="right" className={classes.timestamp}>
-                                        {format(parseISO(oldMessage.createdAt), "dd/MM HH:mm")}
-                                    </TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
-            </DialogContent>
-            <DialogActions>
-                <Button
-                    autoFocus
-                    onClick={() => onClose(false)}
+  return (
+    <Dialog
+      open={open}
+      onClose={() => onClose(false)}
+      aria-labelledby="dialog-title"
+    >
+      <DialogTitle id="dialog-title">{i18n.t("messageHistoryModal.title")}</DialogTitle>
+      <DialogContent>
+        <TableContainer>
+          <Table aria-label="message-history-table">
+            <TableBody>
+              {oldMessages?.map((oldMessage) => (
+                <TableRow
+                  key={oldMessage.id}
                 >
-                    {i18n.t("messageHistoryModal.close")}
-                </Button>
-            </DialogActions>
+                  <TableCell component="th" scope="row">
+                    {oldMessage.body}
+                  </TableCell>
+                  <TableCell align="right" className={classes.timestamp}>
+                    {format(parseISO(oldMessage.createdAt), "dd/MM HH:mm")}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          autoFocus
+          onClick={() => onClose(false)}
+        >
+          {i18n.t("messageHistoryModal.close")}
+        </Button>
+      </DialogActions>
 
-        </Dialog>
-    );
+    </Dialog>
+  );
+};
+
+MessageHistoryModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  oldMessages: PropTypes.array
 };
 
 export default MessageHistoryModal;

--- a/frontend/src/components/MessageInput/index.js
+++ b/frontend/src/components/MessageInput/index.js
@@ -417,7 +417,10 @@ const MessageInput = ({ ticketStatus }) => {
           aria-label="showRecorder"
           component="span"
           disabled={loading || ticketStatus !== "open"}
-          onClick={() => setReplyingMessage(null)}
+          onClick={() => {
+            setReplyingMessage(null);
+            setEditingMessage(null);
+          }}
         >
           <ClearIcon className={classes.sendMessageIcons} />
         </IconButton>

--- a/frontend/src/components/MessageInput/index.js
+++ b/frontend/src/components/MessageInput/index.js
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { Picker } from "emoji-mart";
 import MicRecorder from "mic-recorder-to-mp3";
 import clsx from "clsx";
+import PropTypes from "prop-types";
 
 import { makeStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
@@ -211,7 +212,7 @@ const MessageInput = ({ ticketStatus }) => {
   const [showEmoji, setShowEmoji] = useState(false);
   const [loading, setLoading] = useState(false);
   const [recording, setRecording] = useState(false);
-  const [quickAnswers, setQuickAnswer] = useState([]);
+  const [quickAnswers, setQuickAnswers] = useState([]);
   const [typeBar, setTypeBar] = useState(false);
   const inputRef = useRef();
   const [anchorEl, setAnchorEl] = useState(null);
@@ -339,7 +340,7 @@ const MessageInput = ({ ticketStatus }) => {
         const { data } = await api.get("/quickAnswers/", {
           params: { searchParam: inputMessage.substring(1) },
         });
-        setQuickAnswer(data.quickAnswers);
+        setQuickAnswers(data.quickAnswers);
         if (data.quickAnswers.length > 0) {
           setTypeBar(true);
         } else {
@@ -683,5 +684,9 @@ const MessageInput = ({ ticketStatus }) => {
     );
   }
 };
+
+MessageInput.propTypes = {
+  ticketStatus: PropTypes.string
+}
 
 export default MessageInput;

--- a/frontend/src/components/MessageOptionsMenu/index.js
+++ b/frontend/src/components/MessageOptionsMenu/index.js
@@ -7,10 +7,12 @@ import api from "../../services/api";
 import ConfirmationModal from "../ConfirmationModal";
 import { Menu } from "@material-ui/core";
 import { ReplyMessageContext } from "../../context/ReplyingMessage/ReplyingMessageContext";
+import { EditMessageContext } from "../../context/EditingMessage/EditingMessageContext";
 import toastError from "../../errors/toastError";
 
 const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
   const { setReplyingMessage } = useContext(ReplyMessageContext);
+  const { setEditingMessage } = useContext(EditMessageContext);
   const [confirmationOpen, setConfirmationOpen] = useState(false);
 
   const handleDeleteMessage = async () => {
@@ -21,7 +23,7 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
     }
   };
 
-  const hanldeReplyMessage = () => {
+  const handleReplyMessage = () => {
     setReplyingMessage(message);
     handleClose();
   };
@@ -30,6 +32,11 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
     setConfirmationOpen(true);
     handleClose();
   };
+
+  const handleEditMessage = async () => {
+    setEditingMessage(message);
+    handleClose();
+  }
 
   return (
     <>
@@ -55,12 +62,15 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
         open={menuOpen}
         onClose={handleClose}
       >
-        {message.fromMe && (
-          <MenuItem onClick={handleOpenConfirmationModal}>
+        {message.fromMe && [
+          <MenuItem key="delete" onClick={handleOpenConfirmationModal}>
             {i18n.t("messageOptionsMenu.delete")}
+          </MenuItem>,
+          <MenuItem key="edit" onClick={handleEditMessage}>
+            {i18n.t("messageOptionsMenu.edit")}
           </MenuItem>
-        )}
-        <MenuItem onClick={hanldeReplyMessage}>
+        ]}
+        <MenuItem key="reply" onClick={handleReplyMessage}>
           {i18n.t("messageOptionsMenu.reply")}
         </MenuItem>
       </Menu>

--- a/frontend/src/components/MessageOptionsMenu/index.js
+++ b/frontend/src/components/MessageOptionsMenu/index.js
@@ -9,11 +9,13 @@ import { Menu } from "@material-ui/core";
 import { ReplyMessageContext } from "../../context/ReplyingMessage/ReplyingMessageContext";
 import { EditMessageContext } from "../../context/EditingMessage/EditingMessageContext";
 import toastError from "../../errors/toastError";
+import MessageHistoryModal from "../MessageHistoryModal";
 
 const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
   const { setReplyingMessage } = useContext(ReplyMessageContext);
   const { setEditingMessage } = useContext(EditMessageContext);
   const [confirmationOpen, setConfirmationOpen] = useState(false);
+  const [messageHistoryOpen, setMessageHistoryOpen] = useState(false);
 
   const handleDeleteMessage = async () => {
     try {
@@ -38,6 +40,11 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
     handleClose();
   }
 
+  const handleOpenMessageHistoryModal = (e) => {
+    setMessageHistoryOpen(true);
+    handleClose();
+  }
+
   return (
     <>
       <ConfirmationModal
@@ -48,6 +55,12 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
       >
         {i18n.t("messageOptionsMenu.confirmationModal.message")}
       </ConfirmationModal>
+      <MessageHistoryModal
+        open={messageHistoryOpen}
+        onClose={setMessageHistoryOpen}
+        oldMessages={message.oldMessages}
+      >
+      </MessageHistoryModal>
       <Menu
         anchorEl={anchorEl}
         getContentAnchorEl={null}
@@ -70,6 +83,11 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
             {i18n.t("messageOptionsMenu.edit")}
           </MenuItem>
         ]}
+        {message.oldMessages?.length > 0 && (
+          <MenuItem key="history" onClick={handleOpenMessageHistoryModal}>
+            {i18n.t("messageOptionsMenu.history")}
+          </MenuItem>
+        )}
         <MenuItem key="reply" onClick={handleReplyMessage}>
           {i18n.t("messageOptionsMenu.reply")}
         </MenuItem>

--- a/frontend/src/components/MessageOptionsMenu/index.js
+++ b/frontend/src/components/MessageOptionsMenu/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from "react";
+import PropTypes from "prop-types";
 
 import MenuItem from "@material-ui/core/MenuItem";
 
@@ -95,5 +96,12 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
     </>
   );
 };
+
+MessageOptionsMenu.propTypes = {
+  message: PropTypes.object,
+  menuOpen: PropTypes.bool.isRequired,
+  handleClose: PropTypes.func.isRequired,
+  anchorEl: PropTypes.object
+}
 
 export default MessageOptionsMenu;

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -31,6 +31,7 @@ import whatsBackground from "../../assets/wa-background.png";
 import api from "../../services/api";
 import toastError from "../../errors/toastError";
 import Audio from "../Audio";
+import { i18n } from "../../translate/i18n";
 
 const useStyles = makeStyles((theme) => ({
   messagesListWrapper: {
@@ -596,87 +597,87 @@ const MessagesList = ({ ticketId, isGroup }) => {
   };
 
   const renderMessages = () => {
-      const viewMessagesList = messagesList.map((message, index) => {
-        if (!message.fromMe) {
-          return (
-            <React.Fragment key={message.id}>
-              {renderDailyTimestamps(message, index)}
-              {renderMessageDivider(message, index)}
-              <div className={classes.messageLeft}>
-                <IconButton
-                  variant="contained"
-                  size="small"
-                  id="messageActionsButton"
-                  disabled={message.isDeleted}
-                  className={classes.messageActionsButton}
-                  onClick={(e) => handleOpenMessageOptionsMenu(e, message)}
-                >
-                  <ExpandMore />
-                </IconButton>
-                {isGroup && (
-                  <span className={classes.messageContactName}>
-                    {message.contact?.name}
-                  </span>
+    const viewMessagesList = messagesList.map((message, index) => {
+      if (!message.fromMe) {
+        return (
+          <React.Fragment key={message.id}>
+            {renderDailyTimestamps(message, index)}
+            {renderMessageDivider(message, index)}
+            <div className={classes.messageLeft}>
+              <IconButton
+                variant="contained"
+                size="small"
+                id="messageActionsButton"
+                disabled={message.isDeleted}
+                className={classes.messageActionsButton}
+                onClick={(e) => handleOpenMessageOptionsMenu(e, message)}
+              >
+                <ExpandMore />
+              </IconButton>
+              {isGroup && (
+                <span className={classes.messageContactName}>
+                  {message.contact?.name}
+                </span>
+              )}
+              {(message.mediaUrl || message.mediaType === "location" || message.mediaType === "vcard"
+                //|| message.mediaType === "multi_vcard" 
+              ) && checkMessageMedia(message)}
+              <div className={classes.textContentItem}>
+                {message.quotedMsg && renderQuotedMessage(message)}
+                <MarkdownWrapper>{message.body}</MarkdownWrapper>
+                <span className={classes.timestamp}>
+                  {format(parseISO(message.createdAt), "HH:mm")}
+                </span>
+              </div>
+            </div>
+          </React.Fragment>
+        );
+      } else {
+        return (
+          <React.Fragment key={message.id}>
+            {renderDailyTimestamps(message, index)}
+            {renderMessageDivider(message, index)}
+            <div className={classes.messageRight}>
+              <IconButton
+                variant="contained"
+                size="small"
+                id="messageActionsButton"
+                disabled={message.isDeleted}
+                className={classes.messageActionsButton}
+                onClick={(e) => handleOpenMessageOptionsMenu(e, message)}
+              >
+                <ExpandMore />
+              </IconButton>
+              {(message.mediaUrl || message.mediaType === "location" || message.mediaType === "vcard"
+                //|| message.mediaType === "multi_vcard" 
+              ) && checkMessageMedia(message)}
+              <div
+                className={clsx(classes.textContentItem, {
+                  [classes.textContentItemDeleted]: message.isDeleted,
+                  [classes.textContentItemEdited] : message.isEdited
+                })}
+              >
+                {message.isDeleted && (
+                  <Block
+                    color="disabled"
+                    fontSize="small"
+                    className={classes.deletedIcon}
+                  />
                 )}
-                {(message.mediaUrl || message.mediaType === "location" || message.mediaType === "vcard"
-                  //|| message.mediaType === "multi_vcard" 
-                ) && checkMessageMedia(message)}
-                <div className={classes.textContentItem}>
-                  {message.quotedMsg && renderQuotedMessage(message)}
-                  <MarkdownWrapper>{message.body}</MarkdownWrapper>
-                  <span className={classes.timestamp}>
-                    {format(parseISO(message.createdAt), "HH:mm")}
-                  </span>
-                </div>
+                {message.quotedMsg && renderQuotedMessage(message)}
+                <MarkdownWrapper>{message.body}</MarkdownWrapper>
+                <span className={classes.timestamp}>
+                  {message.isEdited && <span>{i18n.t("message.edited")} </span>}
+                  {format(parseISO(message.createdAt), "HH:mm")}
+                  {renderMessageAck(message)}
+                </span>
               </div>
-            </React.Fragment>
-          );
-        } else {
-          return (
-            <React.Fragment key={message.id}>
-              {renderDailyTimestamps(message, index)}
-              {renderMessageDivider(message, index)}
-              <div className={classes.messageRight}>
-                <IconButton
-                  variant="contained"
-                  size="small"
-                  id="messageActionsButton"
-                  disabled={message.isDeleted}
-                  className={classes.messageActionsButton}
-                  onClick={(e) => handleOpenMessageOptionsMenu(e, message)}
-                >
-                  <ExpandMore />
-                </IconButton>
-                {(message.mediaUrl || message.mediaType === "location" || message.mediaType === "vcard"
-                  //|| message.mediaType === "multi_vcard" 
-                ) && checkMessageMedia(message)}
-                <div
-                  className={clsx(classes.textContentItem, {
-                    [classes.textContentItemDeleted]: message.isDeleted,
-                    [classes.textContentItemEdited] : message.isEdited
-                  })}
-                >
-                  {message.isDeleted && (
-                    <Block
-                      color="disabled"
-                      fontSize="small"
-                      className={classes.deletedIcon}
-                    />
-                  )}
-                  {message.quotedMsg && renderQuotedMessage(message)}
-                  <MarkdownWrapper>{message.body}</MarkdownWrapper>
-                  <span className={classes.timestamp}>
-                    {message.isEdited && <span>Editada </span>}
-                    {format(parseISO(message.createdAt), "HH:mm")}
-                    {renderMessageAck(message)}
-                  </span>
-                </div>
-              </div>
-            </React.Fragment>
-          );
-        }
-      });
-      return viewMessagesList;
+            </div>
+          </React.Fragment>
+        );
+      }
+    });
+    return viewMessagesList;
   };
 
   return (

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -622,10 +622,15 @@ const MessagesList = ({ ticketId, isGroup }) => {
               {(message.mediaUrl || message.mediaType === "location" || message.mediaType === "vcard"
                 //|| message.mediaType === "multi_vcard" 
               ) && checkMessageMedia(message)}
-              <div className={classes.textContentItem}>
+              <div
+                className={clsx(classes.textContentItem, {
+                  [classes.textContentItemEdited] : message.isEdited
+                })}
+              >
                 {message.quotedMsg && renderQuotedMessage(message)}
                 <MarkdownWrapper>{message.body}</MarkdownWrapper>
                 <span className={classes.timestamp}>
+                  {message.isEdited && <span>{i18n.t("message.edited")} </span>}
                   {format(parseISO(message.createdAt), "HH:mm")}
                 </span>
               </div>

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useReducer, useRef } from "react";
+import PropTypes from "prop-types";
 
 import { isSameDay, parseISO, format } from "date-fns";
 import openSocket from "../../services/socket-io";
@@ -708,5 +709,10 @@ const MessagesList = ({ ticketId, isGroup }) => {
     </div>
   );
 };
+
+MessagesList.propTypes = {
+  ticketId: PropTypes.string.isRequired,
+  isGroup: PropTypes.bool 
+}
 
 export default MessagesList;

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -197,6 +197,11 @@ const useStyles = makeStyles((theme) => ({
     padding: "3px 80px 6px 6px",
   },
 
+  textContentItemEdited: {
+    overflowWrap: "break-word",
+    padding: "3px 120px 6px 6px",
+  },
+
   messageMedia: {
     objectFit: "cover",
     width: 250,
@@ -649,6 +654,7 @@ const MessagesList = ({ ticketId, isGroup }) => {
                 <div
                   className={clsx(classes.textContentItem, {
                     [classes.textContentItemDeleted]: message.isDeleted,
+                    [classes.textContentItemEdited] : message.isEdited
                   })}
                 >
                   {message.isDeleted && (
@@ -661,6 +667,7 @@ const MessagesList = ({ ticketId, isGroup }) => {
                   {message.quotedMsg && renderQuotedMessage(message)}
                   <MarkdownWrapper>{message.body}</MarkdownWrapper>
                   <span className={classes.timestamp}>
+                    {message.isEdited && <span>Editada </span>}
                     {format(parseISO(message.createdAt), "HH:mm")}
                     {renderMessageAck(message)}
                   </span>

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -596,7 +596,6 @@ const MessagesList = ({ ticketId, isGroup }) => {
   };
 
   const renderMessages = () => {
-    if (messagesList.length > 0) {
       const viewMessagesList = messagesList.map((message, index) => {
         if (!message.fromMe) {
           return (
@@ -678,9 +677,6 @@ const MessagesList = ({ ticketId, isGroup }) => {
         }
       });
       return viewMessagesList;
-    } else {
-      return <div>Say hello to your new contact!</div>;
-    }
   };
 
   return (

--- a/frontend/src/components/Ticket/index.js
+++ b/frontend/src/components/Ticket/index.js
@@ -16,6 +16,7 @@ import MessagesList from "../MessagesList";
 import api from "../../services/api";
 import { ReplyMessageProvider } from "../../context/ReplyingMessage/ReplyingMessageContext";
 import toastError from "../../errors/toastError";
+import { EditMessageProvider } from "../../context/EditingMessage/EditingMessageContext";
 
 const drawerWidth = 320;
 
@@ -165,11 +166,13 @@ const Ticket = () => {
           </div>
         </TicketHeader>
         <ReplyMessageProvider>
-          <MessagesList
-            ticketId={ticketId}
-            isGroup={ticket.isGroup}
-          ></MessagesList>
-          <MessageInput ticketStatus={ticket.status} />
+          <EditMessageProvider>
+            <MessagesList
+              ticketId={ticketId}
+              isGroup={ticket.isGroup}
+            ></MessagesList>
+            <MessageInput ticketStatus={ticket.status} />
+          </EditMessageProvider>
         </ReplyMessageProvider>
       </Paper>
       <ContactDrawer

--- a/frontend/src/context/EditingMessage/EditingMessageContext.js
+++ b/frontend/src/context/EditingMessage/EditingMessageContext.js
@@ -1,4 +1,5 @@
 import React, { useState, createContext } from "react";
+import PropTypes from "prop-types";
 
 const EditMessageContext = createContext();
 
@@ -13,5 +14,9 @@ const EditMessageProvider = ({ children }) => {
 		</EditMessageContext.Provider>
 	);
 };
+
+EditMessageProvider.propTypes = {
+	children: PropTypes.array
+}
 
 export { EditMessageContext, EditMessageProvider};

--- a/frontend/src/context/EditingMessage/EditingMessageContext.js
+++ b/frontend/src/context/EditingMessage/EditingMessageContext.js
@@ -1,0 +1,17 @@
+import React, { useState, createContext } from "react";
+
+const EditMessageContext = createContext();
+
+const EditMessageProvider = ({ children }) => {
+	const [editingMessage, setEditingMessage] = useState(null);
+
+	return (
+		<EditMessageContext.Provider
+			value={{ editingMessage, setEditingMessage }}
+		>
+			{children}
+		</EditMessageContext.Provider>
+	);
+};
+
+export { EditMessageContext, EditMessageProvider};

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -420,11 +420,16 @@ const messages = {
       messageOptionsMenu: {
         delete: "Delete",
         edit: "Edit",
+        history: "History",
         reply: "Reply",
         confirmationModal: {
           title: "Delete message?",
           message: "This action cannot be reverted.",
         },
+      },
+      messageHistoryModal: {
+        close: "Cerrar",
+        title: "Historial de edición de mensajes"
       },
       backendErrors: {
         ERR_NO_OTHER_WHATSAPP:

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -428,8 +428,8 @@ const messages = {
         },
       },
       messageHistoryModal: {
-        close: "Cerrar",
-        title: "Historial de edición de mensajes"
+        close: "Close",
+        title: "Message edit history"
       },
       backendErrors: {
         ERR_NO_OTHER_WHATSAPP:

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -416,6 +416,7 @@ const messages = {
       },
       messageOptionsMenu: {
         delete: "Delete",
+        edit: "Edit",
         reply: "Reply",
         confirmationModal: {
           title: "Delete message?",
@@ -438,6 +439,7 @@ const messages = {
         ERR_SENDING_WAPP_MSG:
           "Error sending WhatsApp message. Check connections page.",
         ERR_DELETE_WAPP_MSG: "Couldn't delete message from WhatsApp.",
+        ERR_EDITING_WAPP_MSG: "Couldn't edit message from WhatsApp.",
         ERR_OTHER_OPEN_TICKET:
           "There's already an open ticket for this contact.",
         ERR_SESSION_EXPIRED: "Session expired. Please login.",
@@ -457,7 +459,7 @@ const messages = {
         ERR_QUEUE_COLOR_ALREADY_EXISTS:
           "This color is already in use, pick another one.",
         ERR_WAPP_GREETING_REQUIRED:
-          "Greeting message is required if there is more than one queue.",
+          "Greeting message is required if there is more than one queue.",  
       },
     },
   },

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -388,6 +388,9 @@ const messages = {
         placeholderClosed: "Reopen or accept this ticket to send a message.",
         signMessage: "Sign",
       },
+      message: {
+        edited: "Edited"
+      },
       contactDrawer: {
         header: "Contact details",
         buttons: {

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -394,6 +394,9 @@ const messages = {
           "Vuelva a abrir o acepte este ticket para enviar un mensaje.",
         signMessage: "Firmar",
       },
+      message: {
+        edited: "Editado"
+      },
       contactDrawer: {
         header: "Detalles del contacto",
         buttons: {

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -423,6 +423,7 @@ const messages = {
       },
       messageOptionsMenu: {
         delete: "Borrar",
+        edit: "Editar",
         reply: "Responder",
         confirmationModal: {
           title: "¿Borrar mensaje?",
@@ -445,6 +446,7 @@ const messages = {
         ERR_SENDING_WAPP_MSG:
           "Error al enviar el mensaje de WhatsApp. Verifique la página de conexiones.",
         ERR_DELETE_WAPP_MSG: "No se pudo borrar el mensaje de WhatsApp.",
+        ERR_EDITING_WAPP_MSG: "No se pudo editar el mesaje de WhatsApp.",
         ERR_OTHER_OPEN_TICKET: "Ya hay un ticket abierto para este contacto.",
         ERR_SESSION_EXPIRED: "Sesión caducada. Inicie sesión.",
         ERR_USER_CREATION_DISABLED:

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -435,8 +435,8 @@ const messages = {
         },
       },
       messageHistoryModal: {
-        close: "Close",
-        title: "Message edit history"
+        close: "Cerrar",
+        title: "Historial de edición de mensajes"
       },
       backendErrors: {
         ERR_NO_OTHER_WHATSAPP:

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -427,11 +427,16 @@ const messages = {
       messageOptionsMenu: {
         delete: "Borrar",
         edit: "Editar",
+        history: "Histórico",
         reply: "Responder",
         confirmationModal: {
           title: "¿Borrar mensaje?",
           message: "Esta acción no puede ser revertida.",
         },
+      },
+      messageHistoryModal: {
+        close: "Close",
+        title: "Message edit history"
       },
       backendErrors: {
         ERR_NO_OTHER_WHATSAPP:

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -393,6 +393,9 @@ const messages = {
           "Reabra ou aceite esse ticket para enviar uma mensagem.",
         signMessage: "Assinar",
       },
+      message: {
+        edited: "Editada"
+      },
       contactDrawer: {
         header: "Dados do contato",
         buttons: {
@@ -404,7 +407,8 @@ const messages = {
         delete: "Deletar",
         transfer: "Transferir",
         confirmationModal: {
-          title: "Deletar o ticket do contato",
+          title: "Deletar o ticket #",
+          titleFrom: "do contato ",
           message:
             "Atenção! Todas as mensagens relacionadas ao ticket serão perdidas.",
         },

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -426,11 +426,16 @@ const messages = {
       messageOptionsMenu: {
         delete: "Deletar",
         edit: "Editar",
+        history: "Histórico",
         reply: "Responder",
         confirmationModal: {
           title: "Apagar mensagem?",
           message: "Esta ação não pode ser revertida.",
         },
+      },
+      messageHistoryModal: {
+        close: "Fechar",
+        title: "Histórico de edição da mensagem"
       },
       backendErrors: {
         ERR_NO_OTHER_WHATSAPP: "Deve haver pelo menos um WhatsApp padrão.",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -421,6 +421,7 @@ const messages = {
       },
       messageOptionsMenu: {
         delete: "Deletar",
+        edit: "Editar",
         reply: "Responder",
         confirmationModal: {
           title: "Apagar mensagem?",
@@ -443,6 +444,7 @@ const messages = {
         ERR_SENDING_WAPP_MSG:
           "Erro ao enviar mensagem do WhatsApp. Verifique a página de conexões.",
         ERR_DELETE_WAPP_MSG: "Não foi possível excluir a mensagem do WhatsApp.",
+        ERR_EDITING_WAPP_MSG: "Não foi possível editar a mensagem do WhatsApp.",
         ERR_OTHER_OPEN_TICKET: "Já existe um tíquete aberto para este contato.",
         ERR_SESSION_EXPIRED: "Sessão expirada. Por favor entre.",
         ERR_USER_CREATION_DISABLED:


### PR DESCRIPTION
This update allows you to view edited messages, as well as edit sent messages, if possible within the editing deadline.
- It uses the "message_edit" event, available in version 1.22.1 of WhatsApp-Web.js.

**Photos:**
![Old message](https://github.com/canove/whaticket-community/assets/56037523/b3f33cd5-04d3-478b-8f51-a84f12614515)
![Message option menu](https://github.com/canove/whaticket-community/assets/56037523/2e7bd4dd-f6b0-4972-81f8-f12994058e4c)
![Message input](https://github.com/canove/whaticket-community/assets/56037523/c8af65e7-4b67-45b6-8434-16770a77d79a)
![New message](https://github.com/canove/whaticket-community/assets/56037523/30ceb4b2-b10e-4354-bd59-80d6f7fc10a3)

