### PR TITLE
fix: ticket does not return null

### DIFF
--- a/frontend/src/components/TicketActionButtons/index.js
+++ b/frontend/src/components/TicketActionButtons/index.js
@@ -43,6 +43,14 @@ const TicketActionButtons = ({ ticket }) => {
 	const handleUpdateTicketStatus = async (e, status, userId) => {
 		setLoading(true);
 		try {
+			if ( status === "closed") {
+				await api.put(`/tickets/${ticket.id}`, {
+					status: status,
+					userId: userId || null,
+					queueId: null,
+				});
+			}
+
 			await api.put(`/tickets/${ticket.id}`, {
 				status: status,
 				userId: userId || null,


### PR DESCRIPTION
## Set queueId to null when completing ticket

This PR adjusts the system to set queueId to null when completing a ticket. This allows that when called again, the ticket is not associated with any queue, being visible to all users and allowing for re-assignment.

- Associate a ticket with a queue.
- Mark the ticket as completed.
- Verify that the queueId is set to null in the database.
- Confirm that the ticket is callable and visible to everyone.

#pt-br
## Setar queueId como null ao concluir ticket

Este PR ajusta o sistema para definir queueId como null ao concluir um ticket. Isso permite que, ao ser chamado novamente, o ticket não esteja associado a nenhuma fila, ficando visível para todos os usuários e permitindo nova atribuição.

- Associe um ticket a uma fila.
- Marque o ticket como concluído.
- Verifique que queueId foi definido como null no banco de dados.
- Confirme que o ticket pode ser chamado e visto por todos.