### PR TITLE
feat: Adicionado modal e rotas para Encaminhar mensagem.

### DIFF
--- a/backend/src/controllers/MessageController.ts
+++ b/backend/src/controllers/MessageController.ts
@@ -9,6 +9,7 @@ import ShowTicketService from "../services/TicketServices/ShowTicketService";
 import DeleteWhatsAppMessage from "../services/WbotServices/DeleteWhatsAppMessage";
 import SendWhatsAppMedia from "../services/WbotServices/SendWhatsAppMedia";
 import SendWhatsAppMessage from "../services/WbotServices/SendWhatsAppMessage";
+import ForwardMessage from "../helpers/FowardMessage";
 
 type IndexQuery = {
   pageNumber: string;
@@ -72,4 +73,22 @@ export const remove = async (
   });
 
   return res.send();
+};
+
+export const forward = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { toId, uId } = req.query;
+  const { msg } = req.body;
+  if (!toId || !uId || !msg) {
+    return res.status(404).send({ message: "Error" });
+  } else {
+    await ForwardMessage(
+      toId.toString(),
+      parseInt(uId.toString(), 10),
+      JSON.parse(msg)
+    );
+    return res.send("Mensagem encaminhada");
+  }
 };

--- a/backend/src/helpers/FowardMessage.ts
+++ b/backend/src/helpers/FowardMessage.ts
@@ -1,0 +1,33 @@
+import { WAMessage } from "@whiskeysockets/baileys";
+import GetWhatsappWbot from "./GetWhatsappWbot";
+import GetDefaultWhatsAppByUser from "./GetDefaultWhatsAppByUser";
+import Contact from "../models/Contact";
+
+const ForwardMessage = async (toId: string, userId: number, msg: WAMessage) => {
+  const whatsapp = await GetDefaultWhatsAppByUser(userId);
+  const wbot = await GetWhatsappWbot(whatsapp);
+  if (!wbot) {
+    console.log("Nao tem wbot");
+    return;
+  }
+  try {
+    const contact = await Contact.findByPk(toId);
+    if (!contact) return;
+    const chatId = `${contact.number}@${
+      contact.isGroup ? "g.us" : "s.whatsapp.net"
+    }`;
+    try {
+      msg.message.extendedTextMessage.text = `*${msg.pushName}*:\n${msg.message.extendedTextMessage.text}`;
+    } catch (err) {}
+    const send = await wbot.sendMessage(chatId, {
+      forward: msg,
+      force: true
+    });
+    return send;
+  } catch (err) {
+    console.log(err);
+    return;
+  }
+};
+
+export default ForwardMessage;

--- a/backend/src/routes/fowardRoutes.ts
+++ b/backend/src/routes/fowardRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import isAuth from "../middleware/isAuth";
+import * as MessageController from "../controllers/MessageController";
+
+const forwardRoutes = Router();
+
+forwardRoutes.post("/fw", isAuth, MessageController.forward);
+
+export default forwardRoutes;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -11,6 +11,7 @@ import whatsappSessionRoutes from "./whatsappSessionRoutes";
 import queueRoutes from "./queueRoutes";
 import quickAnswerRoutes from "./quickAnswerRoutes";
 import apiRoutes from "./apiRoutes";
+import forwardRoutes from "./fowardRoutes";
 
 const routes = Router();
 
@@ -24,6 +25,7 @@ routes.use(messageRoutes);
 routes.use(whatsappSessionRoutes);
 routes.use(queueRoutes);
 routes.use(quickAnswerRoutes);
+routes.use(forwardRoutes);
 routes.use("/api/messages", apiRoutes);
 
 export default routes;

--- a/frontend/src/components/MessageFowardModal/index.js
+++ b/frontend/src/components/MessageFowardModal/index.js
@@ -1,0 +1,290 @@
+import React, { useState, useEffect, useContext } from "react";
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Autocomplete, {
+  createFilterOptions,
+} from "@material-ui/lab/Autocomplete";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import { makeStyles } from "@material-ui/core/styles";
+import { Grid } from "@material-ui/core";
+import Typography from "@material-ui/core/Typography";
+import { i18n } from "../../translate/i18n";
+import api from "../../services/api";
+import ButtonWithSpinner from "../ButtonWithSpinner";
+import ContactModal from "../ContactModal";
+import toastError from "../../errors/toastError";
+import { AuthContext } from "../../context/Auth/AuthContext";
+
+const useStyles = makeStyles((theme) => ({
+  online: {
+    fontSize: 11,
+    color: "#25d366",
+  },
+  offline: {
+    fontSize: 11,
+    color: "#e1306c",
+  },
+}));
+
+const filter = createFilterOptions({
+  trim: true,
+});
+
+const MessageForwardModal = ({
+  modalOpen,
+  onClose,
+  initialContact,
+  message,
+}) => {
+  const [options, setOptions] = useState([]);
+
+  const [loading, setLoading] = useState(false);
+  const [searchParam, setSearchParam] = useState("");
+  const [selectedContact, setSelectedContact] = useState(null);
+  const [selectedQueue, setSelectedQueue] = useState("");
+  const [selectedWhatsapp, setSelectedWhatsapp] = useState("");
+  const [newContact, setNewContact] = useState({});
+  const [whatsapps, setWhatsapps] = useState([]);
+  const [contactModalOpen, setContactModalOpen] = useState(false);
+  const { user } = useContext(AuthContext);
+  const { companyId, whatsappId } = user;
+  const [openAlert, setOpenAlert] = useState(false);
+
+  useEffect(() => {
+    if (initialContact?.id !== undefined) {
+      setOptions([initialContact]);
+      setSelectedContact(initialContact);
+    }
+  }, [initialContact]);
+
+  useEffect(() => {
+    setLoading(true);
+    const delayDebounceFn = setTimeout(() => {
+      const fetchContacts = async () => {
+        api
+          .get(`/whatsapp`, { params: { companyId, session: 0 } })
+          .then(({ data }) => setWhatsapps(data));
+      };
+
+      if (whatsappId !== null && whatsappId !== undefined) {
+        setSelectedWhatsapp(whatsappId);
+      }
+
+      if (user.queues.length === 1) {
+        setSelectedQueue(user.queues[0].id);
+      }
+      fetchContacts();
+      setLoading(false);
+    }, 500);
+    return () => clearTimeout(delayDebounceFn);
+  }, []);
+
+  useEffect(() => {
+    if (!modalOpen || searchParam.length < 3) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const delayDebounceFn = setTimeout(() => {
+      const fetchContacts = async () => {
+        try {
+          const { data } = await api.get("contacts", {
+            params: { searchParam },
+          });
+          setOptions(data.contacts);
+          setLoading(false);
+        } catch (err) {
+          setLoading(false);
+          toastError(err);
+        }
+      };
+      fetchContacts();
+    }, 500);
+    return () => clearTimeout(delayDebounceFn);
+  }, [searchParam, modalOpen]);
+
+  const forwardMessage = async (message, contactId, userId) => {
+    const remote = message.remoteJid.split("@");
+    console.log(message);
+    await api.post(
+      `/fw?toId=${contactId}&uId=${userId}&gp=${
+        remote[1].includes("g.us") ? 1 : 0
+      }`,
+      { msg: message.dataJson }
+    );
+    return;
+  };
+
+  const handleClose = () => {
+    onClose();
+    setSearchParam("");
+    setOpenAlert(false);
+    setSelectedContact(null);
+  };
+
+  const handleSaveTicket = async (contactId) => {
+    if (!contactId) return;
+    setLoading(true);
+    try {
+      await forwardMessage(message, contactId, user.id);
+      onClose();
+    } catch (err) {
+      onClose();
+    }
+    setLoading(false);
+  };
+
+  const handleSelectOption = (e, newValue) => {
+    if (newValue?.number) {
+      setSelectedContact(newValue);
+    } else if (newValue?.name) {
+      setNewContact({ name: newValue.name });
+      setContactModalOpen(true);
+    }
+  };
+
+  const handleCloseContactModal = () => {
+    setContactModalOpen(false);
+  };
+
+  const handleAddNewContactTicket = (contact) => {
+    handleSaveTicket(contact.id);
+  };
+
+  const createAddContactOption = (filterOptions, params) => {
+    const filtered = filter(filterOptions, params);
+    if (params.inputValue !== "" && !loading && searchParam.length >= 3) {
+      filtered.push({
+        name: `${params.inputValue}`,
+      });
+    }
+    return filtered;
+  };
+
+  const renderOption = (option) => {
+    if (option.number) {
+      return (
+        <>
+          {/* {IconChannel(option.channel)} */}
+          <Typography
+            component="span"
+            style={{
+              fontSize: 14,
+              marginLeft: "10px",
+              display: "inline-flex",
+              alignItems: "center",
+              lineHeight: "2",
+            }}
+          >
+            {option.name} - {option.number}
+          </Typography>
+        </>
+      );
+    } else {
+      return `${i18n.t("messageForward.add")} ${option.name}`;
+    }
+  };
+
+  const renderOptionLabel = (option) => {
+    if (option.number) {
+      return `${option.name} - ${option.number}`;
+    } else {
+      return `${option.name}`;
+    }
+  };
+
+  const renderContactAutocomplete = () => {
+    if (initialContact === undefined || initialContact.id === undefined) {
+      return (
+        <Grid xs={12} item>
+          <Autocomplete
+            fullWidth
+            options={options}
+            loading={loading}
+            clearOnBlur
+            autoHighlight
+            freeSolo
+            clearOnEscape
+            getOptionLabel={renderOptionLabel}
+            renderOption={renderOption}
+            filterOptions={createAddContactOption}
+            onChange={(e, newValue) => handleSelectOption(e, newValue)}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={i18n.t("messageForward.fieldLabel")}
+                variant="outlined"
+                autoFocus
+                onChange={(e) => setSearchParam(e.target.value)}
+                onKeyPress={(e) => {
+                  if (loading || !selectedContact) return;
+                  else if (e.key === "Enter") {
+                    handleSaveTicket(selectedContact.id);
+                  }
+                }}
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <React.Fragment>
+                      {loading ? (
+                        <CircularProgress color="inherit" size={20} />
+                      ) : null}
+                      {params.InputProps.endAdornment}
+                    </React.Fragment>
+                  ),
+                }}
+              />
+            )}
+          />
+        </Grid>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <>
+      <ContactModal
+        open={contactModalOpen}
+        initialValues={newContact}
+        onClose={handleCloseContactModal}
+        onSave={handleAddNewContactTicket}
+      ></ContactModal>
+      <Dialog open={modalOpen} onClose={handleClose}>
+        <DialogTitle id="form-dialog-title">
+          {i18n.t("messageForward.title")}
+        </DialogTitle>
+        <DialogContent dividers>
+          <Grid style={{ width: 300 }} container spacing={2}>
+            {renderContactAutocomplete()}
+          </Grid>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleClose}
+            color="secondary"
+            disabled={loading}
+            variant="outlined"
+          >
+            {i18n.t("messageForward.buttons.cancel")}
+          </Button>
+          <ButtonWithSpinner
+            variant="contained"
+            type="button"
+            disabled={!selectedContact}
+            onClick={() => handleSaveTicket(selectedContact.id)}
+            color="primary"
+            loading={loading}
+          >
+            {i18n.t("messageForward.buttons.ok")}
+          </ButtonWithSpinner>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+export default MessageForwardModal;

--- a/frontend/src/components/MessageFowardModal/index.js
+++ b/frontend/src/components/MessageFowardModal/index.js
@@ -126,7 +126,7 @@ const MessageForwardModal = ({
     setSelectedContact(null);
   };
 
-  const handleSaveTicket = async (contactId) => {
+  const handleForwardMessage = async (contactId) => {
     if (!contactId) return;
     setLoading(true);
     try {
@@ -152,7 +152,7 @@ const MessageForwardModal = ({
   };
 
   const handleAddNewContactTicket = (contact) => {
-    handleSaveTicket(contact.id);
+    handleForwardMessage(contact.id);
   };
 
   const createAddContactOption = (filterOptions, params) => {
@@ -223,7 +223,7 @@ const MessageForwardModal = ({
                 onKeyPress={(e) => {
                   if (loading || !selectedContact) return;
                   else if (e.key === "Enter") {
-                    handleSaveTicket(selectedContact.id);
+                    handleForwardMessage(selectedContact.id);
                   }
                 }}
                 InputProps={{
@@ -276,7 +276,7 @@ const MessageForwardModal = ({
             variant="contained"
             type="button"
             disabled={!selectedContact}
-            onClick={() => handleSaveTicket(selectedContact.id)}
+            onClick={() => handleForwardMessage(selectedContact.id)}
             color="primary"
             loading={loading}
           >

--- a/frontend/src/components/MessageOptionsMenu/index.js
+++ b/frontend/src/components/MessageOptionsMenu/index.js
@@ -5,6 +5,7 @@ import MenuItem from "@material-ui/core/MenuItem";
 import { i18n } from "../../translate/i18n";
 import api from "../../services/api";
 import ConfirmationModal from "../ConfirmationModal";
+import MessageForwardModal from "../MessageFowardModal";
 import { Menu } from "@material-ui/core";
 import { ReplyMessageContext } from "../../context/ReplyingMessage/ReplyingMessageContext";
 import toastError from "../../errors/toastError";
@@ -12,6 +13,7 @@ import toastError from "../../errors/toastError";
 const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
   const { setReplyingMessage } = useContext(ReplyMessageContext);
   const [confirmationOpen, setConfirmationOpen] = useState(false);
+  const [fowardMessage, setFowardMessage] = useState(false);
 
   const handleDeleteMessage = async () => {
     try {
@@ -31,6 +33,15 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
     handleClose();
   };
 
+  const handleForwardMessage = () => {
+    setFowardMessage(true);
+  };
+
+  const handleForwardMessageClose = () => {
+    setFowardMessage(false);
+    handleClose();
+  };
+
   return (
     <>
       <ConfirmationModal
@@ -41,6 +52,11 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
       >
         {i18n.t("messageOptionsMenu.confirmationModal.message")}
       </ConfirmationModal>
+      <MessageForwardModal
+        message={message}
+        onClose={handleForwardMessageClose}
+        modalOpen={fowardMessage}
+      />
       <Menu
         anchorEl={anchorEl}
         getContentAnchorEl={null}
@@ -55,14 +71,17 @@ const MessageOptionsMenu = ({ message, menuOpen, handleClose, anchorEl }) => {
         open={menuOpen}
         onClose={handleClose}
       >
+        <MenuItem onClick={hanldeReplyMessage}>
+          {i18n.t("messageOptionsMenu.reply")}
+        </MenuItem>
+        <MenuItem onClick={handleForwardMessage}>
+          {i18n.t("messageOptionsMenu.forward")}
+        </MenuItem>
         {message.fromMe && (
           <MenuItem onClick={handleOpenConfirmationModal}>
             {i18n.t("messageOptionsMenu.delete")}
           </MenuItem>
         )}
-        <MenuItem onClick={hanldeReplyMessage}>
-          {i18n.t("messageOptionsMenu.reply")}
-        </MenuItem>
       </Menu>
     </>
   );

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -41,15 +41,15 @@ const messages = {
         },
         messages: {
           inAttendance: {
-            title: "In Service"
+            title: "In Service",
           },
           waiting: {
-            title: "Waiting"
+            title: "Waiting",
           },
           closed: {
-            title: "Closed"
-          }
-        }
+            title: "Closed",
+          },
+        },
       },
       connections: {
         title: "Connections",
@@ -384,7 +384,8 @@ const messages = {
         },
       },
       messagesInput: {
-        placeholderOpen: "Type a message or press ''/'' to use the registered quick responses",
+        placeholderOpen:
+          "Type a message or press ''/'' to use the registered quick responses",
         placeholderClosed: "Reopen or accept this ticket to send a message.",
         signMessage: "Sign",
       },
@@ -417,6 +418,7 @@ const messages = {
       messageOptionsMenu: {
         delete: "Delete",
         reply: "Reply",
+        forward: "Forward",
         confirmationModal: {
           title: "Delete message?",
           message: "This action cannot be reverted.",
@@ -458,6 +460,15 @@ const messages = {
           "This color is already in use, pick another one.",
         ERR_WAPP_GREETING_REQUIRED:
           "Greeting message is required if there is more than one queue.",
+      },
+    },
+    messageForward: {
+      title: "Forward Message",
+      fieldLabel: "Type to search for a contact",
+      add: "Add",
+      buttons: {
+        cancel: "Cancel",
+        ok: "Send",
       },
     },
   },

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -42,15 +42,15 @@ const messages = {
         },
         messages: {
           inAttendance: {
-            title: "En servicio"
+            title: "En servicio",
           },
           waiting: {
-            title: "Esperando"
+            title: "Esperando",
           },
           closed: {
-            title: "Finalizado"
-          }
-        }
+            title: "Finalizado",
+          },
+        },
       },
       connections: {
         title: "Conexiones",
@@ -389,7 +389,8 @@ const messages = {
         },
       },
       messagesInput: {
-        placeholderOpen: "Escriba un mensaje o presione '' / '' para usar las respuestas rápidas registradas",
+        placeholderOpen:
+          "Escriba un mensaje o presione '' / '' para usar las respuestas rápidas registradas",
         placeholderClosed:
           "Vuelva a abrir o acepte este ticket para enviar un mensaje.",
         signMessage: "Firmar",
@@ -424,6 +425,7 @@ const messages = {
       messageOptionsMenu: {
         delete: "Borrar",
         reply: "Responder",
+        forward: "Reenviar",
         confirmationModal: {
           title: "¿Borrar mensaje?",
           message: "Esta acción no puede ser revertida.",
@@ -465,6 +467,15 @@ const messages = {
           "Este color ya está en uso, elija otro.",
         ERR_WAPP_GREETING_REQUIRED:
           "El mensaje de saludo es obligatorio cuando hay más de una cola.",
+      },
+    },
+    messageForward: {
+      title: "Reenviar Mensaje",
+      fieldLabel: "Escribe para buscar un contacto",
+      add: "Añadir",
+      buttons: {
+        cancel: "Cancelar",
+        ok: "Enviar",
       },
     },
   },

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -41,15 +41,15 @@ const messages = {
         },
         messages: {
           inAttendance: {
-            title: "Em Atendimento"
+            title: "Em Atendimento",
           },
           waiting: {
-            title: "Aguardando"
+            title: "Aguardando",
           },
           closed: {
-            title: "Finalizado"
-          }
-        }
+            title: "Finalizado",
+          },
+        },
       },
       connections: {
         title: "Conexões",
@@ -108,7 +108,7 @@ const messages = {
         form: {
           name: "Nome",
           default: "Padrão",
-          farewellMessage: "Mensagem de despedida"
+          farewellMessage: "Mensagem de despedida",
         },
         buttons: {
           okAdd: "Adicionar",
@@ -388,7 +388,8 @@ const messages = {
         },
       },
       messagesInput: {
-        placeholderOpen: "Digite uma mensagem ou tecle ''/'' para utilizar as respostas rápidas cadastrada",
+        placeholderOpen:
+          "Digite uma mensagem ou tecle ''/'' para utilizar as respostas rápidas cadastrada",
         placeholderClosed:
           "Reabra ou aceite esse ticket para enviar uma mensagem.",
         signMessage: "Assinar",
@@ -422,6 +423,7 @@ const messages = {
       messageOptionsMenu: {
         delete: "Deletar",
         reply: "Responder",
+        forward: "Encaminhar",
         confirmationModal: {
           title: "Apagar mensagem?",
           message: "Esta ação não pode ser revertida.",
@@ -462,6 +464,15 @@ const messages = {
           "Esta cor já está em uso, escolha outra.",
         ERR_WAPP_GREETING_REQUIRED:
           "A mensagem de saudação é obrigatório quando há mais de uma fila.",
+      },
+    },
+    messageForward: {
+      title: "Encaminhar Mensagem",
+      fieldLabel: "Digite para pesquisar o contato",
+      add: "Adicionar",
+      buttons: {
+        cancel: "Cancelar",
+        ok: "Enviar",
       },
     },
   },


### PR DESCRIPTION
Este PR introduz a funcionalidade de encaminhar mensagens no aplicativo, permitindo que o usuário reenvie conteúdo de um chat para outro de forma simples.

O que foi feito

- Componente UI
  - Criação do ForwardMessageModal, modal responsivo para seleção de chat/destinatário e confirmação do envio.
- Rotas/Backend
  - Implementação de forwardRoutes para receber requisições de encaminhamento via API e persistir o novo envio.
- Menu de opções
  - Atualização do MessageOptionsMenu, adicionando a opção Forward que abre o modal de encaminhamento.

Como testar

1. No chat, clique no ícone de opções de qualquer mensagem.
2. Escolha Forward no menu.
3. No modal que abrir, selecione o chat de destino e confirme o encaminhamento.
4. Verifique se a mensagem aparece corretamente no chat de destino.

Issues relacionadas

#93 
#116 
